### PR TITLE
NPE Fix

### DIFF
--- a/src/fr/toshibane/topluck/TopLuckTable.java
+++ b/src/fr/toshibane/topluck/TopLuckTable.java
@@ -70,7 +70,7 @@ public class TopLuckTable implements Listener {
 		}
 		
 		if (icones) {  // Icones de navigations
-			if (page > 0) { // S'il y a une page prÈcÈdente
+			if (page > 0) { // S'il y a une page pr√©c√©dente
 				ItemStack back = new ItemStack(Material.ARROW, 1);
 				
 				ItemMeta meta = back.getItemMeta();
@@ -111,7 +111,7 @@ public class TopLuckTable implements Listener {
 		PlayerTopLuck targetTL = topluck.getPlayerTopLuckFrom(target);
 		
 		
-		// TÈlÈportation au joueur
+		// T√©l√©portation au joueur
 		ItemStack tp = new ItemStack(Material.ENDER_PEARL, 1);
 		ItemMeta tpMeta = tp.getItemMeta();
 		tpMeta.setDisplayName(topluck.getConfig("Teleport"));
@@ -135,13 +135,13 @@ public class TopLuckTable implements Listener {
 		publicWMeta.setDisplayName(topluck.getConfig("PublicWarn"));
 		publicWarn.setItemMeta(publicWMeta);
 		
-		// Avertir en PrivÈ
+		// Avertir en Priv√©
 		ItemStack privateWarn = new ItemStack(Material.STICK, 1);
 		ItemMeta privateWM = privateWarn.getItemMeta();
 		privateWM.setDisplayName(topluck.getConfig("PrivateWarn"));
 		privateWarn.setItemMeta(privateWM);
 		
-		// Tous ses minerais comptabilisÈs
+		// Tous ses minerais comptabilis√©s
 		int i = 0;
 		for (String mat : targetTL.getMinedBlocks().keySet()) {
 			if (mat != "all") {
@@ -185,9 +185,14 @@ public class TopLuckTable implements Listener {
 			}
 			event.setCancelled(true);
 		}else if (Bukkit.getPlayer(event.getView().getTitle()) != null && event.getCurrentItem() != null && event.getCurrentItem().getItemMeta() != null) {
-			// Si nous sommes dans le menu de dÈtails
+			// Si nous sommes dans le menu de d√©tails
 			String nameItem = event.getCurrentItem().getItemMeta().getDisplayName();
 			Player target = Bukkit.getPlayer(event.getView().getTitle());
+			
+			if(nameItem == null) {
+				event.setCancelled(true);
+				return;
+			}
 			
 			if (nameItem.equals(topluck.getConfig("Teleport"))) {
 				event.getWhoClicked().teleport(Bukkit.getPlayer(event.getView().getTitle()));


### PR DESCRIPTION
Fix error console and ore can be mooving

```
[Server thread/ERROR]: Could not pass event InventoryClickEvent to TopLuck v3.0
org.bukkit.event.EventException: null
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:69) ~[EventExecutor$2.class:git-CatServer-1.12.2-2bce5d5]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[RegisteredListener.class:git-CatServer-1.12.2-2bce5d5]
        at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:503) [SimplePluginManager.class:git-CatServer-1.12.2-2bce5d5]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:488) [SimplePluginManager.class:git-CatServer-1.12.2-2bce5d5]
        at net.minecraft.network.NetHandlerPlayServer.func_147351_a(NetHandlerPlayServer.java:2168) [pa.class:?]
        at net.minecraft.network.play.client.CPacketClickWindow.func_148833_a(CPacketClickWindow.java:38) [lf.class:?]
        at net.minecraft.network.play.client.CPacketClickWindow.func_148833_a(CPacketClickWindow.java:12) [lf.class:?]
        at net.minecraft.network.PacketThreadUtil$1.run(SourceFile:13) [hv$1.class:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) [?:1.8.0_311]
        at java.util.concurrent.FutureTask.run(Unknown Source) [?:1.8.0_311]
        at net.minecraft.util.Util.func_181617_a(SourceFile:46) [h.class:?]
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:890) [MinecraftServer.class:?]
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:474) [nz.class:?]
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:826) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:685) [MinecraftServer.class:?]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_311]
Caused by: java.lang.NullPointerException
        at fr.holo.topluck.TopLuckTable.onInventoryClick(TopLuckTable.java:192) ~[?:?]
        at catserver.server.executor.asm.generated.GeneratedEventExecutor4.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:67) ~[EventExecutor$2.class:git-CatServer-1.12.2-2bce5d5]
        ... 15 more
```